### PR TITLE
Add open endpoint for scheduler callbacks

### DIFF
--- a/mama_ng_control/apps/subscriptions/models.py
+++ b/mama_ng_control/apps/subscriptions/models.py
@@ -24,7 +24,7 @@ class Subscription(models.Model):
     completed = models.BooleanField(default=False)
     schedule = models.IntegerField(default=1)
     process_status = models.IntegerField(default=0, null=False, blank=False)
-    metadata = HStoreField()
+    metadata = HStoreField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/mama_ng_control/apps/subscriptions/urls.py
+++ b/mama_ng_control/apps/subscriptions/urls.py
@@ -9,4 +9,6 @@ router.register(r'subscriptions', views.SubscriptionViewSet)
 # Additionally, we include login URLs for the browseable API.
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url('^subscriptions/(?P<subscription_id>.+)/send$',
+        views.SubscriptionSend.as_view()),
 ]

--- a/mama_ng_control/apps/subscriptions/views.py
+++ b/mama_ng_control/apps/subscriptions/views.py
@@ -1,7 +1,13 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.core.exceptions import ObjectDoesNotExist
+
 from .models import Subscription
 from .serializers import SubscriptionSerializer
+
+from mama_ng_control.apps.vumimessages.models import Outbound
 
 
 class SubscriptionViewSet(viewsets.ModelViewSet):
@@ -14,3 +20,45 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
     serializer_class = SubscriptionSerializer
     filter_fields = ('contact', 'messageset_id', 'lang', 'active', 'completed',
                      'schedule', 'process_status', 'metadata',)
+
+
+class SubscriptionSend(APIView):
+
+    """
+    Triggers a send for the
+    """
+    permission_classes = (AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        """
+        Triggers celery tasks for user
+        """
+        # Look up subscriber
+        subscription_id = kwargs["subscription_id"]
+        try:
+            subscription = Subscription.objects.get(id=subscription_id)
+            expect = ["message-id", "send-counter", "schedule-id"]
+            if set(expect).issubset(request.data.keys()):
+                # Set the next sequence number
+                subscription.next_sequence_number = request.data[
+                    "send-counter"]
+                subscription.save()
+                # Create the message which will trigger send task
+                new_message = Outbound()
+                new_message.contact = subscription.contact
+                new_message.metadata = {}
+                new_message.metadata["scheduler_message_id"] = request.data["message-id"]
+                new_message.metadata["scheduler_schedule_id"] = request.data["schedule-id"]
+                new_message.save()
+                # Return
+                status = 201
+                accepted = {"accepted": True}
+            else:
+                status = 400
+                accepted = {"accepted": False,
+                            "reason": "Missing expected body keys"}
+        except ObjectDoesNotExist:
+            status = 400
+            accepted = {"accepted": False,
+                        "reason": "Missing subscription in control"}
+        return Response(accepted, status=status)

--- a/mama_ng_control/apps/subscriptions/views.py
+++ b/mama_ng_control/apps/subscriptions/views.py
@@ -25,13 +25,13 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
 class SubscriptionSend(APIView):
 
     """
-    Triggers a send for the
+    Triggers a send for the next subscription message
     """
     permission_classes = (AllowAny,)
 
     def post(self, request, *args, **kwargs):
         """
-        Triggers celery tasks for user
+        Validates subscription data before creating Outbound message
         """
         # Look up subscriber
         subscription_id = kwargs["subscription_id"]

--- a/mama_ng_control/apps/subscriptions/views.py
+++ b/mama_ng_control/apps/subscriptions/views.py
@@ -47,8 +47,10 @@ class SubscriptionSend(APIView):
                 new_message = Outbound()
                 new_message.contact = subscription.contact
                 new_message.metadata = {}
-                new_message.metadata["scheduler_message_id"] = request.data["message-id"]
-                new_message.metadata["scheduler_schedule_id"] = request.data["schedule-id"]
+                new_message.metadata["scheduler_message_id"] = \
+                    request.data["message-id"]
+                new_message.metadata["scheduler_schedule_id"] = \
+                    request.data["schedule-id"]
                 new_message.save()
                 # Return
                 status = 201


### PR DESCRIPTION
Not using DRF, just open `/subscriptions/id/send` expecting sequence number in the body, triggers send message celery task
