### PR TITLE
Add open endpoint for vumi callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 services:
   - postgresql
+  - redis
 
 # command to install requirements
 install:

--- a/mama_ng_control/apps/subscriptions/tasks.py
+++ b/mama_ng_control/apps/subscriptions/tasks.py
@@ -1,15 +1,9 @@
-import os
-from redis import Redis
 from celery import task
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
 
-redis = Redis(host=os.environ['MAMA_NG_CONTROL_REDIS_SERVICE'],
-              port=int(os.environ['MAMA_NG_CONTROL_REDIS_PORT']))
-
 
 @task()
 def incr(what):
-    counter = redis.incr(what)
-    return "%s is now: %s" % (what, counter)
+    pass

--- a/mama_ng_control/apps/vumimessages/tasks.py
+++ b/mama_ng_control/apps/vumimessages/tasks.py
@@ -1,15 +1,14 @@
-import os
-from redis import Redis
 from celery import task
 from celery.utils.log import get_task_logger
 
 logger = get_task_logger(__name__)
 
-redis = Redis(host=os.environ['MAMA_NG_CONTROL_REDIS_SERVICE'],
-              port=int(os.environ['MAMA_NG_CONTROL_REDIS_PORT']))
-
 
 @task()
-def incr(what):
-    counter = redis.incr(what)
-    return "%s is now: %s" % (what, counter)
+def send_message(message_id):
+    # make client
+
+    # send message
+
+    # update status
+    pass

--- a/mama_ng_control/apps/vumimessages/tasks.py
+++ b/mama_ng_control/apps/vumimessages/tasks.py
@@ -12,3 +12,10 @@ def send_message(message_id):
 
     # update status
     pass
+
+
+@task()
+def scheduler_ack(message_id):
+    # send ack to scheduler
+
+    pass

--- a/mama_ng_control/apps/vumimessages/tests.py
+++ b/mama_ng_control/apps/vumimessages/tests.py
@@ -48,7 +48,10 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
             "content": "Simple outbound message",
             "delivered": "false",
             "attempts": 1,
-            "metadata": {}
+            "metadata": {
+                "scheduler_message_id": "message-id-1",
+                "scheduler_schedule_id": "schedule-id-1"
+            }
         }
         response = self.client.post('/api/v1/messages/outbound/',
                                     json.dumps(post_data),
@@ -146,7 +149,8 @@ class TestVumiMessagesAPI(AuthenticatedAPITestCase):
         self.assertEqual(str(d.contact.id), str(self.contact))
         self.assertEqual(d.delivered, True)
         self.assertEqual(d.attempts, 2)
-        self.assertEqual(d.metadata, {})
+        self.assertEqual(d.metadata["scheduler_message_id"], "message-id-1")
+        self.assertEqual(d.metadata["scheduler_schedule_id"], "schedule-id-1")
 
     def test_delete_outbound_data(self):
         existing = self.make_outbound()

--- a/mama_ng_control/apps/vumimessages/urls.py
+++ b/mama_ng_control/apps/vumimessages/urls.py
@@ -9,5 +9,7 @@ router.register(r'inbound', views.InboundViewSet)
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browseable API.
 urlpatterns = [
+    url('^events$',
+        views.EventListener.as_view()),
     url(r'^', include(router.urls)),
 ]

--- a/mama_ng_control/apps/vumimessages/views.py
+++ b/mama_ng_control/apps/vumimessages/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from django.core.exceptions import ObjectDoesNotExist
 from .models import Outbound, Inbound
 from .serializers import OutboundSerializer, InboundSerializer
-from .tasks import send_message
+from .tasks import send_message, scheduler_ack
 
 
 class OutboundViewSet(viewsets.ModelViewSet):
@@ -60,6 +60,8 @@ class EventListener(APIView):
                         message.delivered = True
                         message.metadata["ack_timestamp"] = \
                             request.data["timestamp"]
+                        scheduler_ack.delay(
+                            message.metadata["scheduler_message_id"])
                     elif event == "delivery_report":
                         message.delivered = True
                         message.metadata["delivery_timestamp"] = \

--- a/mama_ng_control/apps/vumimessages/views.py
+++ b/mama_ng_control/apps/vumimessages/views.py
@@ -1,7 +1,11 @@
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.core.exceptions import ObjectDoesNotExist
 from .models import Outbound, Inbound
 from .serializers import OutboundSerializer, InboundSerializer
+from .tasks import send_message
 
 
 class OutboundViewSet(viewsets.ModelViewSet):
@@ -27,3 +31,58 @@ class InboundViewSet(viewsets.ModelViewSet):
     filter_fields = ('message_id', 'in_reply_to', 'to_addr', 'from_addr',
                      'content', 'transport_name', 'transport_type',
                      'helper_metadata', 'created_at', 'updated_at',)
+
+
+class EventListener(APIView):
+
+    """
+    Triggers updates to outbound messages based on event data from Vumi
+    """
+    permission_classes = (AllowAny,)
+
+    def post(self, request, *args, **kwargs):
+        """
+        Checks for expect event types before continuing
+        """
+
+        try:
+            expect = ["message_type", "event_type", "user_message_id",
+                      "event_id", "timestamp"]
+            if set(expect).issubset(request.data.keys()):
+                # Load message
+                message = Outbound.objects.get(
+                    vumi_message_id=request.data["user_message_id"])
+                # only expecting `event` on this endpoint
+                if request.data["message_type"] == "event":
+                    event = request.data["event_type"]
+                    # expecting ack, nack, delivery_report
+                    if event == "ack":
+                        message.delivered = True
+                        message.metadata["ack_timestamp"] = \
+                            request.data["timestamp"]
+                    elif event == "delivery_report":
+                        message.delivered = True
+                        message.metadata["delivery_timestamp"] = \
+                            request.data["timestamp"]
+                    elif event == "nack":
+                        if "nack_reason" in request.data:
+                            message.metadata["nack_reason"] = \
+                                request.data["nack_reason"]
+                        send_message.delay(str(message.id))
+                    message.save()
+                    # Return
+                    status = 200
+                    accepted = {"accepted": True}
+                else:
+                    status = 400
+                    accepted = {"accepted": False,
+                                "reason": "Unexpected message_type"}
+            else:
+                status = 400
+                accepted = {"accepted": False,
+                            "reason": "Missing expected body keys"}
+        except ObjectDoesNotExist:
+            status = 400
+            accepted = {"accepted": False,
+                        "reason": "Missing message in control"}
+        return Response(accepted, status=status)


### PR DESCRIPTION
Not DRF, for ack and nack messages from message sends. Format documented here: http://vumi-go.readthedocs.org/en/latest/http_api.html#events

Acks should update the messages.Outbound model and trigger task to tell Scheduler delivered

Nacks should trigger retry unless limited reached which should trigger Failure tasks
